### PR TITLE
Initialize Flask intranet skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Company Intranet
+
+This is a minimal Flask-based intranet prototype with local user authentication and role-based access control. It uses server-side rendered HTML templates styled with Bootstrap 5.
+
+## Features
+- Local user registration and login with hashed passwords
+- Role field for future RBAC (admin, manager, user)
+- Department field on the user for data separation
+- Designed to extend to other authentication providers (e.g., Google SSO)
+- Blueprint structure for modular tools
+
+Run the development server:
+
+```bash
+python -m intranet.app
+```

--- a/intranet/app.py
+++ b/intranet/app.py
@@ -1,0 +1,37 @@
+from flask import Flask, render_template
+from flask_login import LoginManager
+
+from .config import Config
+from .models import db, User
+from .auth import auth_bp
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object(Config)
+
+    db.init_app(app)
+
+    login_manager = LoginManager()
+    login_manager.login_view = 'auth.login'
+    login_manager.init_app(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
+    app.register_blueprint(auth_bp)
+
+    @app.route('/')
+    def index():
+        return render_template('index.html')
+
+    with app.app_context():
+        db.create_all()
+
+    return app
+
+
+if __name__ == '__main__':
+    app = create_app()
+    app.run(debug=True)

--- a/intranet/auth/__init__.py
+++ b/intranet/auth/__init__.py
@@ -1,0 +1,3 @@
+from .routes import auth_bp
+
+__all__ = ['auth_bp']

--- a/intranet/auth/forms.py
+++ b/intranet/auth/forms.py
@@ -1,0 +1,20 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, PasswordField, SubmitField
+from wtforms.validators import DataRequired, Email, EqualTo
+
+
+class LoginForm(FlaskForm):
+    username = StringField('Username', validators=[DataRequired()])
+    password = PasswordField('Password', validators=[DataRequired()])
+    submit = SubmitField('Login')
+
+
+class RegistrationForm(FlaskForm):
+    username = StringField('Username', validators=[DataRequired()])
+    email = StringField('Email', validators=[DataRequired(), Email()])
+    department = StringField('Department', validators=[DataRequired()])
+    password = PasswordField('Password', validators=[DataRequired()])
+    confirm_password = PasswordField(
+        'Confirm Password', validators=[DataRequired(), EqualTo('password')]
+    )
+    submit = SubmitField('Register')

--- a/intranet/auth/routes.py
+++ b/intranet/auth/routes.py
@@ -1,0 +1,51 @@
+from flask import Blueprint, render_template, redirect, url_for, flash
+from flask_login import login_user, logout_user, login_required, current_user
+
+from .forms import LoginForm, RegistrationForm
+from ..models import db, User
+
+
+auth_bp = Blueprint('auth', __name__, url_prefix='/auth')
+
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if current_user.is_authenticated:
+        return redirect(url_for('index'))
+    form = LoginForm()
+    if form.validate_on_submit():
+        user = User.query.filter_by(username=form.username.data).first()
+        if user and user.check_password(form.password.data):
+            login_user(user)
+            return redirect(url_for('index'))
+        flash('Invalid credentials')
+    return render_template('auth/login.html', form=form)
+
+
+@auth_bp.route('/register', methods=['GET', 'POST'])
+def register():
+    if current_user.is_authenticated:
+        return redirect(url_for('index'))
+    form = RegistrationForm()
+    if form.validate_on_submit():
+        if User.query.filter_by(username=form.username.data).first():
+            flash('Username already exists')
+        else:
+            user = User(
+                username=form.username.data,
+                email=form.email.data,
+                department=form.department.data,
+            )
+            user.set_password(form.password.data)
+            db.session.add(user)
+            db.session.commit()
+            flash('Registration successful, please login')
+            return redirect(url_for('auth.login'))
+    return render_template('auth/register.html', form=form)
+
+
+@auth_bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('auth.login'))

--- a/intranet/config.py
+++ b/intranet/config.py
@@ -1,0 +1,6 @@
+import os
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'sqlite:///intranet.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/intranet/models.py
+++ b/intranet/models.py
@@ -1,0 +1,25 @@
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import UserMixin
+from werkzeug.security import generate_password_hash, check_password_hash
+
+
+db = SQLAlchemy()
+
+
+class User(db.Model, UserMixin):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128))
+    role = db.Column(db.String(20), default='user')
+    department = db.Column(db.String(50), nullable=False)
+
+    # For future SSO providers
+    auth_provider = db.Column(db.String(20), default='local')
+    provider_id = db.Column(db.String(120), unique=True)
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)

--- a/intranet/static/theme.css
+++ b/intranet/static/theme.css
@@ -1,0 +1,3 @@
+body {
+    padding-top: 20px;
+}

--- a/intranet/templates/auth/login.html
+++ b/intranet/templates/auth/login.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">
+    {{ form.username.label(class="form-label") }}
+    {{ form.username(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    {{ form.password.label(class="form-label") }}
+    {{ form.password(class="form-control") }}
+  </div>
+  {{ form.submit(class="btn btn-primary") }}
+</form>
+{% endblock %}

--- a/intranet/templates/auth/register.html
+++ b/intranet/templates/auth/register.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block title %}Register{% endblock %}
+{% block content %}
+<h2>Register</h2>
+<form method="post">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">
+    {{ form.username.label(class="form-label") }}
+    {{ form.username(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    {{ form.email.label(class="form-label") }}
+    {{ form.email(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    {{ form.department.label(class="form-label") }}
+    {{ form.department(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    {{ form.password.label(class="form-label") }}
+    {{ form.password(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    {{ form.confirm_password.label(class="form-label") }}
+    {{ form.confirm_password(class="form-control") }}
+  </div>
+  {{ form.submit(class="btn btn-primary") }}
+</form>
+{% endblock %}

--- a/intranet/templates/base.html
+++ b/intranet/templates/base.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='theme.css') }}">
+  <title>{% block title %}Intranet{% endblock %}</title>
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="{{ url_for('index') }}">Intranet</a>
+      <div class="collapse navbar-collapse">
+        <ul class="navbar-nav ms-auto">
+          {% if current_user.is_authenticated %}
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a></li>
+          {% else %}
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.login') }}">Login</a></li>
+          {% endif %}
+        </ul>
+      </div>
+    </div>
+  </nav>
+  <div class="container">
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        {% for msg in messages %}
+        <div class="alert alert-info">{{ msg }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+  </div>
+</body>
+</html>

--- a/intranet/templates/index.html
+++ b/intranet/templates/index.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}Home{% endblock %}
+{% block content %}
+<h1>Welcome to the Intranet</h1>
+{% if current_user.is_authenticated %}
+<p>Hello, {{ current_user.username }}!</p>
+{% else %}
+<p>Please <a href="{{ url_for('auth.login') }}">login</a>.</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- set up base Flask application with local authentication
- add user model with fields for future SSO
- provide login and registration pages extending `base.html`
- include minimal Bootstrap theme and index page
- add README with basic run instructions

## Testing
- `python -m intranet.app` (runs Flask server)


------
https://chatgpt.com/codex/tasks/task_e_6867a706dd1c833183a0a03ac06de113