### PR TITLE
Implement authentication blueprint with login/logout

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from flask import Flask
-from flask_login import LoginManager
+from flask_login import LoginManager, login_required, current_user
 
 from config import Config, BASE_DIR
 from models import db, User, Department, Role, AuditLog
@@ -15,6 +15,7 @@ def create_app(config_class=Config):
 
     db.init_app(app)
     login_manager.init_app(app)
+    login_manager.login_view = 'auth.login'
 
     @login_manager.user_loader
     def load_user(user_id):
@@ -25,6 +26,13 @@ def create_app(config_class=Config):
 
     from blueprints.standby import standby_bp
     app.register_blueprint(standby_bp)
+
+    @app.route('/dashboard')
+    @login_required
+    def dashboard():
+        return (
+            f"Welcome {current_user.username} from Department {current_user.department_id}"
+        )
 
     return app
 

--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -1,7 +1,7 @@
 from flask import Blueprint
 
+# Blueprint for authentication routes
 auth_bp = Blueprint('auth', __name__)
 
-@auth_bp.route('/login')
-def login():
-    return 'Login Page'
+# Import routes to register them with the blueprint
+from . import routes  # noqa: E402,F401

--- a/auth/routes.py
+++ b/auth/routes.py
@@ -1,0 +1,37 @@
+"""Routes for authentication blueprint."""
+
+from flask import render_template, request, redirect, url_for, flash
+from flask_login import login_user, logout_user, login_required
+from werkzeug.security import check_password_hash
+
+from models import User
+from . import auth_bp
+
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    """Display and process the login form."""
+    if request.method == 'POST':
+        email = request.form.get('email')
+        password = request.form.get('password')
+
+        user = User.query.filter_by(email=email).first()
+        if user and check_password_hash(user.password_hash, password):
+            login_user(user)
+            flash('Logged in successfully.', 'success')
+            next_page = request.args.get('next')
+            return redirect(next_page or url_for('dashboard'))
+
+        flash('Invalid email or password.', 'danger')
+        return redirect(url_for('auth.login'))
+
+    return render_template('login.html')
+
+
+@auth_bp.route('/logout')
+@login_required
+def logout():
+    """Log the user out and redirect to login."""
+    logout_user()
+    flash('You have been logged out.', 'info')
+    return redirect(url_for('auth.login'))

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,10 +2,13 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/theme.css') }}">
     <title>{% block title %}Intranet{% endblock %}</title>
 </head>
 <body>
     {% block content %}{% endblock %}
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+
+{% block title %}Login{% endblock %}
+
+{% block content %}
+<div class="container mt-5" style="max-width: 400px;">
+    <h2 class="mb-4">Login</h2>
+    {% with messages = get_flashed_messages(with_categories=True) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                    {{ message }}
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                </div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+    <form method="post">
+        <div class="mb-3">
+            <label for="email" class="form-label">Email address</label>
+            <input type="email" class="form-control" id="email" name="email" required>
+        </div>
+        <div class="mb-3">
+            <label for="password" class="form-label">Password</label>
+            <input type="password" class="form-control" id="password" name="password" required>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Login</button>
+    </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `auth/routes.py` with login and logout routes using Flask-Login
- register auth blueprint and remove placeholder route
- add `/dashboard` test route requiring login
- add Bootstrap-based `login.html` template
- include Bootstrap assets in `base.html`

## Testing
- `python -m py_compile app.py auth/__init__.py auth/routes.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_6867c3498fcc8331bb775a874c50fc61